### PR TITLE
add control option to fix reg preds to a base year

### DIFF
--- a/Hirsch_sites.yml
+++ b/Hirsch_sites.yml
@@ -16,6 +16,7 @@ minDaysPerYear: 345 # number of days required for a year to be included in the m
 regMaxNaNsPerMonth: 0 # affects rloadest models only: max NaN days allowed for including a month in monthly loads; estimates with NaNs can be very slow
 regMaxNaNsPerSeason: 0 # affects rloadest models only: max NaN days allowed for including a season in seasonal loads; estimates with NaNs can be very slow
 regMaxNaNsPerYear: 0 # affects rloadest models only: max NaN days allowed for including year in annual or multi-year loads; estimates with NaNs can be very slow
+regBaseYear: 2003 # can be a numeric year to fix all regression predictions to that year, or NA to leave them unfixed
 
 # Units for output
 loadUnits: "kg"

--- a/batchHelperFunctions.R
+++ b/batchHelperFunctions.R
@@ -6,6 +6,7 @@ readInputs <- function(control_file) {
   expected <- c(
     "inputFolder","constituents","discharge","date","siteInfo",
     "models","resolutions","minDaysPerYear","regMaxNaNsPerMonth","regMaxNaNsPerSeason","regMaxNaNsPerYear",
+    "regBaseYear",
     "loadUnits","loadRateUnits",
     "outputFolder","outputTimestamp")
   miss <- setdiff(expected, names(inputs))

--- a/three_ANA_sites.yml
+++ b/three_ANA_sites.yml
@@ -16,6 +16,7 @@ minDaysPerYear: 345 # number of days required for a year to be included in the m
 regMaxNaNsPerMonth: 0 # affects rloadest models only: max NaN days allowed for including a month in monthly loads; estimates with NaNs can be very slow
 regMaxNaNsPerSeason: 0 # affects rloadest models only: max NaN days allowed for including a season in seasonal loads; estimates with NaNs can be very slow
 regMaxNaNsPerYear: 0 # affects rloadest models only: max NaN days allowed for including year in annual or multi-year loads; estimates with NaNs can be very slow
+regBaseYear: 2012 # can be a numeric year to fix all regression predictions to that year, or NA to leave them unfixed
 
 # Units for output
 loadUnits: "kg"


### PR DESCRIPTION
addresses step 2 of USGS-R/loadflex#228: Add a flag to the control file for specifying a base year (or predicting without base year) for regression models